### PR TITLE
Create ingress via TLS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,24 @@ You can skip this step. Images are already deployed to Docker Hub repository
     . scripts/4-joinfed.sh
     ```
 
-1. deploy service, ingress and replica set
+1. create an SSL certificate for your ingress host (foo.bar.com is fine for this example)
 
     ```
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=foo.bar.com"
+    ```
+
+1. deploy secret, service, ingress and replica set
+
+    ```
+    kubectl --context=federation create secret tls ing-secret --key /tmp/tls.key --cert /tmp/tls.crt
     kubectl --context=federation create -f services/k8shserver.yaml
     kubectl --context=federation create -f ingress/k8shserver.yaml
     kubectl --context=federation create -f rs/k8shserver.yaml
     ```
     
-1. query the service
-
+1. query the service. It may take a few minutes for ingress to allocate the IP.
+    ```
+    kubectl --context=federation get ing
+    NAME         HOSTS     ADDRESS         PORTS     AGE
+    k8shserver   *         130.211.19.38   80, 443   1m
+    ```

--- a/ingress/k8shserver.yaml
+++ b/ingress/k8shserver.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: k8shserver
 spec:
+  tls:
+    - secretName: ing-secret
   backend:
     serviceName: k8shserver
     servicePort: 80


### PR DESCRIPTION
Update README in the process. The behavior of the GLBC is such that creating an ingress via TLS causes it to allocate and manage a static IP on its own, until the ingress is deleted.